### PR TITLE
add: compilerOptions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules/*", "__sapper__/*", "public/*"]
+  "exclude": ["node_modules/*", "__sapper__/*", "public/*"],
+  "compilerOptions": {
+    "types": ["svelte"],
+  }
 }


### PR DESCRIPTION
```shell
(!) Plugin typescript: @rollup/plugin-typescript TS2307: Cannot find module './Oclock.svelte' or its corresponding type declarations.
src/main.ts: (1:20)

1 import Oclock from "./Oclock.svelte";
                     ~~~~~~~~~~~~~~~~~

(!) Plugin typescript: @rollup/plugin-typescript TS2307: Cannot find module './Seconds.svelte' or its corresponding type declarations.
src/main.ts: (2:21)

2 import Seconds from "./Seconds.svelte";
                      ~~~~~~~~~~~~~~~~~~
```

fix warning 